### PR TITLE
Follow-up: slow jobs polling fallback to avoid rate-limit lockout

### DIFF
--- a/src/lib/__tests__/serverJobs.test.ts
+++ b/src/lib/__tests__/serverJobs.test.ts
@@ -127,6 +127,39 @@ describe('serverJobs', () => {
         );
     });
 
+    it('falls back to polling at a rate that stays under server rate limits', async () => {
+        vi.stubEnv('VITE_API_PROXY_URL', 'http://server');
+
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue(
+                makeJsonResponse({
+                    bookId: 'book-1',
+                    status: 'queued',
+                    totalChapters: 1,
+                    accessToken: 'token-xyz',
+                }),
+            ),
+        );
+
+        const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+        vi.stubGlobal(
+            'EventSource',
+            vi.fn().mockImplementation(function () {
+                throw new Error('SSE unavailable');
+            }) as unknown as typeof EventSource,
+        );
+
+        await submitBookForServerProcessing('book-1', 'My Novel', SAMPLE_CHAPTERS, 'openai');
+
+        const cleanup = connectToJobEvents('book-1', vi.fn(), vi.fn(), vi.fn());
+
+        expect(setIntervalSpy).toHaveBeenCalled();
+        expect(setIntervalSpy.mock.calls[0][1]).toBe(4000);
+
+        cleanup();
+        setIntervalSpy.mockRestore();
+    });
     it('throws on non-OK API responses', async () => {
         vi.stubEnv('VITE_API_PROXY_URL', 'http://server');
 

--- a/src/lib/serverJobs.ts
+++ b/src/lib/serverJobs.ts
@@ -3,6 +3,7 @@
  */
 
 const jobAccessTokens = new Map<string, string>();
+const JOBS_FALLBACK_POLL_INTERVAL_MS = 4000;
 
 function getConfiguredApiBase(): string | undefined {
     const viteValue = import.meta.env.VITE_API_PROXY_URL as string | undefined;
@@ -304,7 +305,7 @@ export function connectToJobEvents(
             } finally {
                 pollInFlight = false;
             }
-        }, 2000);
+        }, JOBS_FALLBACK_POLL_INTERVAL_MS);
     }
 
     return cleanup;


### PR DESCRIPTION
### Motivation
- Prevent clients from hitting the new `/api/jobs` rate limit when SSE is unavailable by reducing fallback polling frequency.  

### Description
- Introduced a named constant `JOBS_FALLBACK_POLL_INTERVAL_MS = 4000` and used it in `connectToJobEvents` to increase the polling interval from `2000` to `4000` milliseconds in `src/lib/serverJobs.ts`.  
- Added a regression test in `src/lib/__tests__/serverJobs.test.ts` that simulates SSE construction failure and asserts that the fallback `setInterval` is scheduled with a `4000` ms interval.  
- Changes touch only the frontend job client and its tests (`src/lib/serverJobs.ts`, `src/lib/__tests__/serverJobs.test.ts`).  

### Testing
- Ran the targeted test file with `npm test -- src/lib/__tests__/serverJobs.test.ts` and the test run succeeded with all tests passing (5 tests passed).  
- Verified the new test checks that fallback polling is scheduled at `4000` ms to keep a single client under the backend default `JOBS_RATE_MAX_REQUESTS`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0defda5e8832db8962c19b1ace30c)